### PR TITLE
Performance improvements for large dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,7 @@
   :license {:name "Apache License, Version 2.0"
             :url  "http://www.apache.org/licenses/LICENSE-2.0.html"}
   :eval-in-leiningen true
+  :dependencies [[org.clojure/tools.cli "1.0.214"]]
   :deploy-repositories [["releases" {:url "https://repo.clojars.org"
                                      :sign-releases false
                                      :username :env/clojars_username

--- a/resources/test/proto_repo/protos/dir4/v1/file4.proto
+++ b/resources/test/proto_repo/protos/dir4/v1/file4.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+package dir4.v1;
+
+message Proto4 {
+  string prop = 1;
+}

--- a/test/leiningen/protodeps_test.clj
+++ b/test/leiningen/protodeps_test.clj
@@ -4,27 +4,70 @@
   (:import [java.nio.file Path]
            [java.io File]))
 
-(deftest integration-test
+(defn- run-test! [test]
   (let [^Path tmp-dir (sut/create-temp-dir!)]
     (try
-      (let [config {:output-path (str tmp-dir)
-                    :proto-version "3.11.3"
-                    :repos '{:repo1 {:repo-type :filesystem
-                                     :config {:path "./resources/test/proto_repo"}
-                                     :proto-paths ["protos"]
-                                     :dependencies [protos/dir1]}
-                             ;; external dependency repo, no direct schemas to compile
-                             :repo2 {:repo-type :filesystem
-                                     :config {:path "./resources/test/proto_repo2"}
-                                     :proto-paths ["protos"]}}}]
-        (sut/generate-files! {} config)
-        (is (= #{"dir1/v1/File1.java" "dir2/v1/File2.java" "dir3/v1/File3.java"}
-               (->> (.toFile tmp-dir)
-                    file-seq
-                    (filter #(not (.isDirectory ^File %)))
-                    (map #(.relativize tmp-dir (.toPath ^File %)))
-                    (map str)
-                    set))))
+      (test tmp-dir)
       (finally
         (sut/cleanup-dir! tmp-dir)))))
 
+(deftest integration-test
+  (run-test!
+   (fn [tmp-dir]
+     (let [config {:output-path (str tmp-dir)
+                   :proto-version "3.11.3"
+                   :repos '{:repo1 {:repo-type :filesystem
+                                    :config {:path "./resources/test/proto_repo"}
+                                    :proto-paths ["protos"]
+                                    :dependencies [protos]}
+                            ;; external dependency repo, no direct schemas to compile
+                            :repo2 {:repo-type :filesystem
+                                    :config {:path "./resources/test/proto_repo2"}
+                                    :proto-paths ["protos"]}}}]
+       (sut/generate-files! {} config)
+       (is (= #{"dir1/v1/File1.java" "dir2/v1/File2.java" "dir3/v1/File3.java" "dir4/v1/File4.java"}
+              (->> (.toFile tmp-dir)
+                   file-seq
+                   (filter #(not (.isDirectory ^File %)))
+                   (map #(.relativize tmp-dir (.toPath ^File %)))
+                   (map str)
+                   set))))))
+  (run-test!
+   (fn [tmp-dir]
+     (let [config {:output-path (str tmp-dir)
+                   :proto-version "3.11.3"
+                   :repos '{:repo1 {:repo-type :filesystem
+                                    :config {:path "./resources/test/proto_repo"}
+                                    :proto-paths ["protos"]
+                                    :dependencies [protos/dir1]}
+                            ;; external dependency repo, no direct schemas to compile
+                            :repo2 {:repo-type :filesystem
+                                    :config {:path "./resources/test/proto_repo2"}
+                                    :proto-paths ["protos"]}}}]
+       (sut/generate-files! {} config)
+       (is (= #{"dir1/v1/File1.java" "dir2/v1/File2.java" "dir3/v1/File3.java"}
+              (->> (.toFile tmp-dir)
+                   file-seq
+                   (filter #(not (.isDirectory ^File %)))
+                   (map #(.relativize tmp-dir (.toPath ^File %)))
+                   (map str)
+                   set))))))
+  (run-test!
+   (fn [tmp-dir]
+     (let [config {:output-path (str tmp-dir)
+                   :proto-version "3.11.3"
+                   :repos '{:repo1 {:repo-type :filesystem
+                                    :config {:path "./resources/test/proto_repo"}
+                                    :proto-paths ["protos"]}
+                            :repo2 {:repo-type :filesystem
+                                    :config {:path "./resources/test/proto_repo2"}
+                                    :proto-paths ["protos"]
+                                    :dependencies [protos/dir3]}}}]
+       (sut/generate-files! {} config)
+       (is (= #{"dir3/v1/File3.java"}
+              (->> (.toFile tmp-dir)
+                   file-seq
+                   (filter #(not (.isDirectory ^File %)))
+                   (map #(.relativize tmp-dir (.toPath ^File %)))
+                   (map str)
+                   set)))))))


### PR DESCRIPTION
closes #5 

* Fixed creation of huge lazy seqs that resulted in eventual stack overflow in repos with thousands of file dependencies.
* Added option for parallelizing discovery stage and compilation stage. This can significantly increase performance for repos with such a high number of dependencies.
* Replaced janky CLI parsing with `clojure.tools.cli` to allow passing `--parallelism` flag.