### PR TITLE
Fix `aarch64` arch name

### DIFF
--- a/.github/workflows/ci_master.yml
+++ b/.github/workflows/ci_master.yml
@@ -76,6 +76,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
         
       - name: Set up JDK 8
         uses: actions/setup-java@v4
@@ -109,15 +112,19 @@ jobs:
           git config --global user.email "<>"
           git config --global push.followTags true
           lein pom
-          export VERSION=$(grep "<version>" pom.xml | head -1 | cut -d ">" -f2 | cut -d "<" -f1)
-          echo "version is:" $VERSION
-          if [[ !("$VERSION" =~ $RELEASE_REGEX) ]]
+          export ORIGINAL_VERSION=$(less pom.xml | grep "<version>" | head -1 | cut -d ">" -f2 | cut -d "<" -f1)
+          echo "Original version is:" $ORIGINAL_VERSION
+          lein change version leiningen.release/bump-version release
+          lein do vcs commit, install
+          lein pom
+          export RELEASE_VERSION=$(less pom.xml | grep "<version>" | head -1 | cut -d ">" -f2 | cut -d "<" -f1)
+          echo "Release version is:" $RELEASE_VERSION
+          if [[ !("$RELEASE_VERSION" =~ $RELEASE_REGEX) ]]
           then
-            echo "Version isn't a release version:" $VERSION ", skipping deployment to Clojars..."
+            echo "Version isn't a release version:" $RELEASE_VERSION ", skipping deployment to Clojars..."
             exit 0
           fi
           lein deploy
-          echo "Release version:" $VERSION"; commit: "${{github.sha}}"; successfully deployed to Clojars"
-          export TAG_NAME="v$VERSION"
-          git tag -a -m "Version $VERSION" $TAG_NAME
-          git push origin $TAG_NAME
+          echo "Release version:" $RELEASE_VERSION"; commit: "${{github.sha}}"; successfully deployed to Clojars"
+          git tag -a $RELEASE_VERSION -m "Release version $RELEASE_VERSION"
+          git push origin master

--- a/.github/workflows/ci_master.yml
+++ b/.github/workflows/ci_master.yml
@@ -56,6 +56,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles( 'project.clj' ) }}
           restore-keys: |
             ${{ runner.os }}-maven-
+            
+      - name: Install Leiningen
+        run: |
+          wget https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein
+          chmod +x lein
+          sudo mv lein /usr/local/bin/
+          lein version
 
       - name: Unit tests
         env:
@@ -83,6 +90,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles( 'project.clj' ) }}
           restore-keys: |
             ${{ runner.os }}-maven-
+            
+      - name: Install Leiningen
+        run: |
+          wget https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein
+          chmod +x lein
+          sudo mv lein /usr/local/bin/
+          lein version
 
       - name: Deploy release version
         env:

--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -1,8 +1,11 @@
-name: "Release"
+name: "CI - Pull Requests"
 
 on:
-  push:
+  pull_request:
     branches:
+      - master
+  push:
+    branches-ignore:
       - master
 
 jobs:
@@ -33,8 +36,8 @@ jobs:
           version: '2025.07.28'
           
       - name: Lint
-        run: clj-kondo --lint src test  
- 
+        run: clj-kondo --lint src test
+
   test:
     needs: build
     runs-on: ubuntu-latest
@@ -62,10 +65,12 @@ jobs:
           IP_STACK_ACCESS_KEY: ${{ secrets.IP_STACK_ACCESS_KEY }}
         run: lein test
 
-  deploy:
+  deploy-snapshot:
     needs: test
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # Only deploy snapshots for pushes to non-master branches (not PRs)
+    if: github.event_name == 'push' && github.ref != 'refs/heads/master'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -84,26 +89,21 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Deploy release version
+      - name: Deploy SNAPSHOT version
         env:
-          RELEASE_REGEX: ^[0-9]{1,2}[.][0-9]{1,2}[.][0-9]{1,3}$
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SNAPSHOT_REGEX: ^[0-9]{1,2}[.][0-9]{1,2}[.][0-9]{1,3}-SNAPSHOT$
           CLOJARS_USERNAME: ${{ secrets.CLOJARS_USERNAME }}
           CLOJARS_PASSWORD: ${{ secrets.CLOJARS_PASSWORD }}
         run: |
           git config --global user.name "github-actions-bot"
           git config --global user.email "<>"
-          git config --global push.followTags true
           lein pom
           export VERSION=$(grep "<version>" pom.xml | head -1 | cut -d ">" -f2 | cut -d "<" -f1)
           echo "version is:" $VERSION
-          if [[ !("$VERSION" =~ $RELEASE_REGEX) ]]
+          if [[ !("$VERSION" =~ $SNAPSHOT_REGEX) ]]
           then
-            echo "Version isn't a release version:" $VERSION ", skipping deployment to Clojars..."
+            echo "Version isn't a SNAPSHOT version:" $VERSION ", skipping deployment to Clojars..."
             exit 0
           fi
           lein deploy
-          echo "Release version:" $VERSION"; commit: "${{github.sha}}"; successfully deployed to Clojars"
-          export TAG_NAME="v$VERSION"
-          git tag -a -m "Version $VERSION" $TAG_NAME
-          git push origin $TAG_NAME
+          echo "SNAPSHOT version:" $VERSION"; commit: "${{github.sha}}"; branch: "${{github.ref_name}}"; successfully deployed to Clojars"

--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches:
       - master
-  push:
-    branches-ignore:
-      - master
 
 jobs:
   build:
@@ -59,6 +56,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles( 'project.clj' ) }}
           restore-keys: |
             ${{ runner.os }}-maven-
+            
+      - name: Install Leiningen
+        run: |
+          wget https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein
+          chmod +x lein
+          sudo mv lein /usr/local/bin/
+          lein version
 
       - name: Unit tests
         env:
@@ -69,8 +73,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # Only deploy snapshots for pushes to non-master branches (not PRs)
-    if: github.event_name == 'push' && github.ref != 'refs/heads/master'
+    # Deploy snapshots for PRs so they can be tested elsewhere
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -88,6 +91,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles( 'project.clj' ) }}
           restore-keys: |
             ${{ runner.os }}-maven-
+            
+      - name: Install Leiningen
+        run: |
+          wget https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein
+          chmod +x lein
+          sudo mv lein /usr/local/bin/
+          lein version
 
       - name: Deploy SNAPSHOT version
         env:
@@ -106,4 +116,4 @@ jobs:
             exit 0
           fi
           lein deploy
-          echo "SNAPSHOT version:" $VERSION"; commit: "${{github.sha}}"; branch: "${{github.ref_name}}"; successfully deployed to Clojars"
+          echo "SNAPSHOT version:" $VERSION"; commit: "${{github.sha}}"; PR: "${{github.event.pull_request.number}}"; successfully deployed to Clojars"

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ pom.xml.asc
 .idea/
 lein-protodeps.iml
 .cider-repl-history
+.java-version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Change Log
+# Changelog
 
 All notable changes to this project will be documented in this file.
 
@@ -6,4 +6,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.0.6] - 2025-08-07
+
+### Fixed
+* Fix aarch64 architecture mapping for protoc binary downloads. The `os-arch->arch` map now correctly maps `"aarch64"` to `"aarch_64"` to match the actual protoc binary naming convention.
+
+### Added
+* Unit tests for aarch64 architecture fix to ensure correct URL generation for protoc downloads.
+* GitHub Actions workflows for CI/CD:
+  * `ci_pr.yml` - Runs tests and deploys SNAPSHOT versions on pull requests
+  * `ci_master.yml` - Runs tests and handles release deployments on master branch merges
+* Modern CI configuration using latest Ubuntu runners and updated action versions.
+
 ### Changed
+* Updated GitHub Actions workflows to use:
+  * `ubuntu-latest` runners
+  * `actions/checkout@v4`
+  * `actions/setup-java@v4` 
+  * `actions/cache@v4`
+  * `clj-kondo` version `2025.07.28`
+* Optimized Leiningen installation in CI to only run where needed.
+* Added `.java-version` to `.gitignore`.
+
+[1.0.6]: https://github.com/AppsFlyer/lein-protodeps/compare/1.0.5...1.0.6

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ are not already installed.
 
 ## Usage
 
-Put `[com.appsflyer/lein-protodeps "1.0.5"]` into the `:plugins` vector of your project.clj.
+Put `[com.appsflyer/lein-protodeps "1.0.6"]` into the `:plugins` vector of your project.clj.
 
 Once installed, run `lein protodeps generate` to run the plugin.
 
@@ -97,7 +97,7 @@ However, it is possible to override these to other endpoints by setting `:protoc
 The values of these options are URL templates that will be interpolated at runtime with the following variables to produce download URLs:
 
 * `:os-name` host OS (i.e, `linux`, `osx`)
-* `:os-arch` host architecture (i.e, `x86_64`, `aarch64`)
+* `:os-arch` host architecture (i.e, `x86_64`, `aarch_64`). Note: `aarch64` systems are automatically mapped to `aarch_64` to match protoc binary naming conventions
 * `:semver` version string as defined in `:protoc-version` or `:grpc-version`
 * `:major` major part of `:semver`
 * `:minor` minor part of `:semver`

--- a/src/leiningen/protodeps.clj
+++ b/src/leiningen/protodeps.clj
@@ -138,7 +138,7 @@
       (recur))))
 
 (def os-name->os {"Linux" "linux" "Mac OS X" "osx"})
-(def os-arch->arch {"amd64" "x86_64" "x86_64" "x86_64" "aarch64" "aarch64"})
+(def os-arch->arch {"amd64" "x86_64" "x86_64" "x86_64" "aarch64" "aarch_64"})
 
 
 (defn get-prop [env prop-name]

--- a/test/leiningen/protodeps_test.clj
+++ b/test/leiningen/protodeps_test.clj
@@ -79,19 +79,23 @@
 
 (deftest aarch64-url-generation-test
   (testing "Test that protoc download URL is correctly generated for aarch64 architecture"
-    (let [platform {:os-name "linux" :os-arch "aarch_64" :semver "24.3"}
-          url-template "https://github.com/protocolbuffers/protobuf/releases/download/v${:semver}/protoc-${:semver}-${:os-name}-${:os-arch}.zip"
-          expected-url "https://github.com/protocolbuffers/protobuf/releases/download/v24.3/protoc-24.3-linux-aarch_64.zip"]
+    (let [platform      {:os-name "linux"
+                         :os-arch "aarch_64"
+                         :semver  "24.3"}
+          url-template  "https://github.com/protocolbuffers/protobuf/releases/download/v${:semver}/protoc-${:semver}-${:os-name}-${:os-arch}.zip"
+          expected-url  "https://github.com/protocolbuffers/protobuf/releases/download/v24.3/protoc-24.3-linux-aarch_64.zip"]
       (is (= expected-url (@#'sut/interpolate platform url-template))
           "URL should be correctly generated with aarch_64 architecture name"))))
 
 (deftest aarch64-issue-8-fix-test
   (testing "Test that the fix for GitHub issue #8 works correctly"
-    (let [platform {:os-name "linux" :os-arch "aarch_64" :semver "24.3"}
-          url-template "https://github.com/protocolbuffers/protobuf/releases/download/v${:semver}/protoc-${:semver}-${:os-name}-${:os-arch}.zip"
+    (let [platform      {:os-name "linux"
+                         :os-arch "aarch_64" 
+                         :semver  "24.3"}
+          url-template  "https://github.com/protocolbuffers/protobuf/releases/download/v${:semver}/protoc-${:semver}-${:os-name}-${:os-arch}.zip"
           generated-url (@#'sut/interpolate platform url-template)
           ;; The issue mentioned the correct URL should have aarch_64 (with underscore)
-          correct-url "https://github.com/protocolbuffers/protobuf/releases/download/v24.3/protoc-24.3-linux-aarch_64.zip"
+          correct-url   "https://github.com/protocolbuffers/protobuf/releases/download/v24.3/protoc-24.3-linux-aarch_64.zip"
           ;; The issue mentioned the incorrect URL was aarch64 (without underscore)
           incorrect-url "https://github.com/protocolbuffers/protobuf/releases/download/v24.3/protoc-24.3-linux-aarch64.zip"]
       (is (= correct-url generated-url)

--- a/test/leiningen/protodeps_test.clj
+++ b/test/leiningen/protodeps_test.clj
@@ -1,6 +1,6 @@
 (ns leiningen.protodeps-test
   (:require [leiningen.protodeps :as sut]
-            [clojure.test :refer [deftest is]])
+            [clojure.test :refer [deftest is testing]])
   (:import [java.nio.file Path]
            [java.io File]))
 
@@ -71,3 +71,30 @@
                    (map #(.relativize tmp-dir (.toPath ^File %)))
                    (map str)
                    set)))))))
+
+(deftest aarch64-architecture-mapping-test
+  (testing "Test that aarch64 architecture is correctly mapped to aarch_64 for protoc download URLs"
+    (is (= "aarch_64" (get sut/os-arch->arch "aarch64"))
+        "aarch64 should map to aarch_64 for correct protoc binary download URL")))
+
+(deftest aarch64-url-generation-test
+  (testing "Test that protoc download URL is correctly generated for aarch64 architecture"
+    (let [platform {:os-name "linux" :os-arch "aarch_64" :semver "24.3"}
+          url-template "https://github.com/protocolbuffers/protobuf/releases/download/v${:semver}/protoc-${:semver}-${:os-name}-${:os-arch}.zip"
+          expected-url "https://github.com/protocolbuffers/protobuf/releases/download/v24.3/protoc-24.3-linux-aarch_64.zip"]
+      (is (= expected-url (@#'sut/interpolate platform url-template))
+          "URL should be correctly generated with aarch_64 architecture name"))))
+
+(deftest aarch64-issue-8-fix-test
+  (testing "Test that the fix for GitHub issue #8 works correctly"
+    (let [platform {:os-name "linux" :os-arch "aarch_64" :semver "24.3"}
+          url-template "https://github.com/protocolbuffers/protobuf/releases/download/v${:semver}/protoc-${:semver}-${:os-name}-${:os-arch}.zip"
+          generated-url (@#'sut/interpolate platform url-template)
+          ;; The issue mentioned the correct URL should have aarch_64 (with underscore)
+          correct-url "https://github.com/protocolbuffers/protobuf/releases/download/v24.3/protoc-24.3-linux-aarch_64.zip"
+          ;; The issue mentioned the incorrect URL was aarch64 (without underscore)
+          incorrect-url "https://github.com/protocolbuffers/protobuf/releases/download/v24.3/protoc-24.3-linux-aarch64.zip"]
+      (is (= correct-url generated-url)
+          "Generated URL should match the correct format with aarch_64")
+      (is (not= incorrect-url generated-url)
+          "Generated URL should NOT match the incorrect format with aarch64"))))


### PR DESCRIPTION
Fixed #8:
- Add tests for `aarch64 -> aarch_64` mapping
- Add tests for URL generation with correct architecture
- Add a workflow for PRs to push `-SNAPSHOT` builds